### PR TITLE
Improvements to the PHP version

### DIFF
--- a/php/README.md
+++ b/php/README.md
@@ -24,7 +24,7 @@ composer install
 
 Run all the tests
 
-```shell script
+```sh
 composer tests
 ```
 

--- a/php/README.md
+++ b/php/README.md
@@ -6,7 +6,7 @@ See the [top level readme](../README.md) for general information about this Kata
 
 The kata uses:
 
-- [PHP 7.3 or 7.4 or 8.0+](https://www.php.net/downloads.php)
+- [PHP 8.0+](https://www.php.net/downloads.php)
 - [Composer](https://getcomposer.org)
 
 Recommended:

--- a/php/README.md
+++ b/php/README.md
@@ -19,7 +19,6 @@ create a local copy of this project on your computer.
 Install all the dependencies using composer
 
 ```sh
-cd Yatzy-Refactoring-Kata/php
 composer install
 ```
 

--- a/php/composer.json
+++ b/php/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "emilybache/yatzy-refactoring-kata",
-    "description": "Kata to practice refactoring",
+    "name": "emilybache/sample-kata",
+    "description": "A kata starter.",
     "license": "MIT",
     "require": {
         "php": "^8.0"

--- a/php/composer.json
+++ b/php/composer.json
@@ -14,12 +14,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Yatzy\\": "src/"
+            "Sample\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Yatzy\\Tests\\": "tests/"
+            "Sample\\Tests\\": "tests/"
         }
     },
     "scripts": {

--- a/php/composer.json
+++ b/php/composer.json
@@ -26,6 +26,7 @@
         "test": "phpunit --no-coverage",
         "tests": "@composer test",
         "test-coverage": "phpunit --coverage-html build/coverage",
+        "tests-coverage": "@composer test-coverage",
         "check-cs": "ecs check --ansi",
         "fix-cs": "ecs check --fix --ansi",
         "phpstan": "phpstan analyse --ansi"

--- a/php/composer.json
+++ b/php/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "scripts": {
-        "tests": "phpunit",
+        "test": "phpunit --no-coverage",
         "test-coverage": "phpunit --coverage-html build/coverage",
         "check-cs": "ecs check --ansi",
         "fix-cs": "ecs check --fix --ansi",

--- a/php/composer.json
+++ b/php/composer.json
@@ -24,6 +24,7 @@
     },
     "scripts": {
         "test": "phpunit --no-coverage",
+        "tests": "@composer test",
         "test-coverage": "phpunit --coverage-html build/coverage",
         "check-cs": "ecs check --ansi",
         "fix-cs": "ecs check --fix --ansi",

--- a/php/composer.json
+++ b/php/composer.json
@@ -6,7 +6,7 @@
         "php": "^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.5|^10.0|^11.0",
         "phpstan/phpstan": "^1.9",
         "phpstan/phpstan-phpunit": "^1.3",
         "symplify/easy-coding-standard": "^11.1",

--- a/php/pu.bat
+++ b/php/pu.bat
@@ -1,1 +1,1 @@
-composer tests
+composer test

--- a/php/tests/SampleTest.php
+++ b/php/tests/SampleTest.php
@@ -13,6 +13,6 @@ class SampleTest extends TestCase
     {
         $expected = 15;
         $actual = 42;
-        $this->assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 }

--- a/php/tests/SampleTest.php
+++ b/php/tests/SampleTest.php
@@ -13,6 +13,6 @@ class SampleTest extends TestCase
     {
         $expected = 15;
         $actual = 42;
-        self::assertSame($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 }


### PR DESCRIPTION
Hello,

I would like to propose a few changes and improvements to the PHP version. This PR:
- fixes the namespaces in the `composer.json` (in the PHP files the namespace is `Sample`)
- renames the `tests` composer's command to `test` (it is more common to [name it test](https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands) and there is a contradiction between `tests` and `test-coverage` commands). However, as I can see, this `tests` command is used in the majority of the repositories with katas, so, probably, it doesn't worth renaming.
- adds new versions of PHPUnit (there is also the 12 version, but probably it is too early to add it because it gives a lot of deprecations)
- fixes the minimum PHP version in the README.md file

**P.S.** I would also recommend to delete all the `.bat` files because they are Windows specific and just duplicate the functionality from the `composer.json`. I would say that using them instead of `composer` is a bad practice (but I don't know the reason behind their existence, maybe they are necessary for CI/CD, however I would also use `composer` directly).

